### PR TITLE
Bugfix: Devise secret_key is required for rails g milia:install

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,12 +303,12 @@ Running the generator below will completely install milia, devise, and a sample 
 need to run the "milia:install" given above. You'll need to do the following:
 
 ```
-  $ rails g milia:install --org_email='<your smtp email for dev work>'
+  $ rails g milia:install --org_email='<your smtp email for dev work>' --secret_key='<your secret key for devise>'
   $ rails g web_app_theme:milia
 ```
-
-NOTE: The above generator has an option to specify an email address to 
+NOTE: The above generator has an option to specify an email address to
 be used for sending emails for confirmation and account activation.
+It also has the option to specify the secret key for devise
 
 The generator set up basic information for
 being able to send the confirmation & activation emails.
@@ -368,12 +368,11 @@ If you'll be working with any beta or leading edge version, specify as follows:
 Then,
 ```
   $ bundle install
-  $ rails g milia:install --org_email='<your smtp email for dev work>'
+  $ rails g milia:install --org_email='<your smtp email for dev work>' --secret_key='<your secret key for devise>'
 ```
-
-Note: The milia generator has an option to specify an email address to be used for sending emails for 
+Note: The milia generator has an option to specify an email address to be used for sending emails for
 confirmation and account activation. Also note that the milia generator runs two
-devise generators.
+devise generators, and that you have the option to specify the secret key that will be used.
 
 Make any changes required to the generated migrations, then:
 ```

--- a/lib/generators/milia/install_generator.rb
+++ b/lib/generators/milia/install_generator.rb
@@ -3,18 +3,19 @@ require 'rails/generators/base'
 module Milia
   module Generators
 # *************************************************************
-    
+
     class InstallGenerator < Rails::Generators::Base
       desc "Full installation of milia with devise"
 
       source_root File.expand_path("../templates", __FILE__)
-  
+
       class_option :use_airbrake, :type => :boolean, :default => false, :desc => 'Use this option to add airbrake exception handling capabilities'
       class_option :skip_recaptcha, :type => :boolean, :default => false, :desc => 'Use this option to skip adding recaptcha for sign ups'
       class_option :skip_invite_member, :type => :boolean, :default => false, :desc => 'Use this option to skip adding invite_member capabilities'
       class_option :skip_env_email_setup, :type => :boolean, :default => false, :desc => 'Use this option to skip adding smtp email info to config/environments/*'
       class_option :org_email, :type => :string, :default => "my-email@my-domain.com", :desc => 'define the organizational email from address'
-       
+      class_option :secret_key, :type => :string, :default => "7a711e3389f793d5fc5264bee405cadb34d410b0eef17f29fef8c4b979999020efac3cf74d0155fbd75249c84f88b4c04c8da6fdb417ba3331dc8996abfc84d3", :desc => 'define the devise secret key configuration option'
+
 # -------------------------------------------------------------
 # -------------------------------------------------------------
   def check_requirements()
@@ -53,6 +54,7 @@ module Milia
 # -------------------------------------------------------------
       def setup_devise
         generate "devise:install"
+        gsub_file 'config/initializers/devise.rb', /# config.secret_key = '.+'/, "config.secret_key = '#{options.secret_key}'"
         generate "devise", "user"
         gsub_file "app/models/user.rb", /,\s*$/, ", :confirmable,"
 


### PR DESCRIPTION
During installation of milia (`rails g milia:install`) I got a lot of exceptions stemming from Devise:

```
ruby-2.0.0-p451@sample-milia-app/gems/devise-3.3.0/lib/devise/rails/routes.rb:483:in `raise_no_secret_key': 
Devise.secret_key was not set. Please add the following to your Devise initializer: (RuntimeError)

  config.secret_key = '0d3234a23d474c8d4c05b60c6dadecd5fdd12392ff000399633aa761f0788f132d004f74599686b48380cad1e86a64a77e6220f96d9522bdd7c79941f3c0572b'
```

The fix is to set secret_key to something (or let the user specify it) in devise.rb before continuing with the script.