### PR TITLE
Improvement: Config for secret_key_base should be added by milia sample app setup

### DIFF
--- a/lib/generators/milia/install_generator.rb
+++ b/lib/generators/milia/install_generator.rb
@@ -36,6 +36,7 @@ module Milia
       def setup_initial_stuff
 
         template 'initializer.rb', 'config/initializers/milia.rb'
+        template 'secret_token.rb', 'config/initializers/secret_token.rb'
 
          unless options.skip_recaptcha
            gem 'recaptcha', :require => "recaptcha/rails"

--- a/lib/generators/milia/templates/secret_token.rb
+++ b/lib/generators/milia/templates/secret_token.rb
@@ -1,0 +1,1 @@
+Rails.application.config.secret_key_base = '8bb5328d010bbec5f29d56203acf10144164447459b036297f3c5ba8f18be8b22ce9c5309f5ac01e05babda2dc458b3dece12de17b1389758593a40d7bd0d982'


### PR DESCRIPTION
Issue:
* In rails 4+ secret_key_base is mandatory parameter, but when following install instructions (rails g milia:install) the app fails due to this is missing

Solution:
* rails g milia:install now adds secret_key_base to the application config/initializers