### PR TITLE
Bugfix: ActionView::Template::Error in sample milia app

### DIFF
--- a/lib/generators/milia/install_generator.rb
+++ b/lib/generators/milia/install_generator.rb
@@ -107,6 +107,12 @@ module Milia
             snippet_model_tenant_determines_tenant
          end
 
+         inject_into_file "config/initializers/assets.rb",
+           after: "# Precompile additional assets.\n" do
+            snippet_precompile_web_app_theme
+         end
+
+
        end  # skip block?
      end
 
@@ -459,6 +465,11 @@ RUBY23
  end
 
 
+  def snippet_precompile_web_app_theme
+<<-'RUBY24'
+    Rails.application.config.assets.precompile += %w( web_app_theme.css )
+RUBY24
+  end
 
 
 # *************************************************************


### PR DESCRIPTION
Issue:
* Clicking sign up crashes the application:
```
ActionView::Template::Error (Asset filtered out and will not be served: add `Rails.application.config.assets.precompile += %w( web_app_theme.css )` to `config/initializers/assets.rb` and restart your server):
```

Solution:
* assets.rb was missing web_app_theme.css, so make sure rails g milia:install adds it